### PR TITLE
Add .venv/ and __pycache__/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ docker/redis/data
 # Test coverage
 coverage/
 .cursor*
+.venv/
+__pycache__/


### PR DESCRIPTION
This PR adds `.venv/` and `__pycache__/` to `.gitignore` to keep them from being tracked by Git.

No other code or logic changes were made.
